### PR TITLE
Make it possible to toggle line comment

### DIFF
--- a/settings/language-gnuplot-atom.cson
+++ b/settings/language-gnuplot-atom.cson
@@ -1,0 +1,3 @@
+'.source.gnuplot':
+  'editor':
+    'commentStart': '# '


### PR DESCRIPTION
fix behavior of editor:toggle-line-comments (`cmd-/` on OSX,  `ctrl-/` on Win)
