### PR TITLE
Specify the comment start symbol

### DIFF
--- a/settings/language-gnuplot.cson
+++ b/settings/language-gnuplot.cson
@@ -1,0 +1,3 @@
+'.source.gnuplot':
+  'editor':
+    'commentStart': '# '


### PR DESCRIPTION
This patch allows atom to use the right symbol for line comments, namely `#` rather than the default `/* ... */`.

Fixes #4 